### PR TITLE
ダイレクトインストールを試す

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -18,19 +18,7 @@ provider:
 functions:
   ordinary:
     handler: dist/index.handler
-    events:
-      - http:
-          path: slack/events
-          method: post
-      - http:
-          path: slack/interactive-endpoint
-          method: post
+    url: true
   installation:
     handler: dist/installation.handler
-    events:
-      - http:
-          path: slack/oauth_redirect
-          method: get
-      - http:
-          path: slack/install
-          method: get
+    url: true

--- a/src/installation.ts
+++ b/src/installation.ts
@@ -20,6 +20,7 @@ const installer = new InstallProvider({
   clientSecret: process.env.SLACK_CLIENT_SECRET!,
   authVersion: 'v2',
   stateSecret: "TEST_STATE_SECRET",
+  directInstall: true,
 });
 
 app.get('/slack/oauth_redirect', async (req, res) => {

--- a/src/installation.ts
+++ b/src/installation.ts
@@ -24,13 +24,35 @@ const installer = new InstallProvider({
 });
 
 app.get('/slack/oauth_redirect', async (req, res) => {
-  await installer.handleCallback(req, res);
+  await installer.handleCallback(req, res, {
+    beforeInstallation: async (options, callbackReq, callbackRes) => {
+      const data = JSON.parse(options.metadata);
+      switch (data.var) {
+        case "test":
+          return true;
+        default:
+          res.end();
+          return false;
+      }
+    },
+  });
 });
 
 app.get('/slack/install', async (req, res) => {
   await installer.handleInstallPath(req, res, {}, {
     scopes,
     userScopes,
+  });
+});
+
+app.get('/:var/slack/install', async (req, res) => {
+  await installer.handleInstallPath(req, res, {
+  }, {
+    scopes,
+    userScopes,
+    metadata: JSON.stringify({
+      var: req.params.var
+    }),
   });
 });
 


### PR DESCRIPTION
Fixes #9

オプションをオンにするだけで行けた

コールバックで表示されるページは
`CallbackOptions` の `success` あるいは `successAsync` に書けば良い．参考実装は [ここ](https://github.com/slackapi/node-slack-sdk/blob/8aa712ba9ff5194fe1715963c6a439818d1b6307/packages/oauth/src/callback-options.ts#L81)

`InstallURLOptions.metadata` にアプリ独特のメタデータを入れるとJWT作成時になんとかしてくれる